### PR TITLE
Small but important fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN python3 -m ensurepip \
 # Clone repo and prepare working directory
 #
 RUN git clone -b sql-extended https://github.com/AvinashReddy3108/PaperplaneExtended /root/userbot
-RUN mkdir /root/userbot/bin
+RUN mkdir /root/userbot/bin/
 WORKDIR /root/userbot/
 
 #


### PR DESCRIPTION
For whatever reason, without the last /, mkdir on Ubuntu 18.04 is creating a file not a directory

The lines 77, 78 still need a look because they're causing issues but this is a step in the right direction