### PR TITLE
Fix Syntax Warnings

### DIFF
--- a/userbot/modules/evaluators.py
+++ b/userbot/modules/evaluators.py
@@ -177,7 +177,7 @@ async def terminal_runner(term):
         remove("output.txt")
         return
 
-    if uid is 0:
+    if uid == 0:
         await term.edit("`" f"{curruser}:~# {command}" f"\n{result}" "`")
     else:
         await term.edit("`" f"{curruser}:~$ {command}" f"\n{result}" "`")

--- a/userbot/modules/memes.py
+++ b/userbot/modules/memes.py
@@ -1054,17 +1054,17 @@ async def scam(event):
     ]
     input_str = event.pattern_match.group(1)
     args = input_str.split()
-    if len(args) is 0:  # Let bot decide action and time
+    if len(args) == 0:  # Let bot decide action and time
         scam_action = choice(options)
         scam_time = randint(30, 60)
-    elif len(args) is 1:  # User decides time/action, bot decides the other.
+    elif len(args) == 1:  # User decides time/action, bot decides the other.
         try:
             scam_action = str(args[0]).lower()
             scam_time = randint(30, 60)
         except ValueError:
             scam_action = choice(options)
             scam_time = int(args[0])
-    elif len(args) is 2:  # User decides both action and time
+    elif len(args) == 2:  # User decides both action and time
         scam_action = str(args[0]).lower()
         scam_time = int(args[1])
     else:


### PR DESCRIPTION
When running the build we get 4 Syntax warnings. This fixes them
SyntaxWarning: "is" with a literal. Did you mean "=="?